### PR TITLE
Default to 1.8s when testing following distance

### DIFF
--- a/selfdrive/controls/lib/lead_mpc.py
+++ b/selfdrive/controls/lib/lead_mpc.py
@@ -13,8 +13,9 @@ MPC_T = list(np.arange(0,1.,.2)) + list(np.arange(1.,10.6,.6))
 
 
 class LeadMpc():
-  def __init__(self, mpc_id):
+  def __init__(self, mpc_id, test=False):
     self.lead_id = mpc_id
+    self.test = test
 
     self.dynamic_follow = DynamicFollow(mpc_id)
     self.reset_mpc()
@@ -88,7 +89,10 @@ class LeadMpc():
       a_lead = 0.0
       self.a_lead_tau = _LEAD_ACCEL_TAU
 
-    TR = self.dynamic_follow.update(CS, self.libmpc)  # update dynamic follow
+    if not test:
+      TR = self.dynamic_follow.update(CS, self.libmpc)  # update dynamic follow
+    else:
+      TR = 1.8
 
     # Calculate mpc
     t = sec_since_boot()

--- a/selfdrive/controls/lib/lead_mpc.py
+++ b/selfdrive/controls/lib/lead_mpc.py
@@ -89,7 +89,7 @@ class LeadMpc():
       a_lead = 0.0
       self.a_lead_tau = _LEAD_ACCEL_TAU
 
-    if not test:
+    if not self.test:
       TR = self.dynamic_follow.update(CS, self.libmpc)  # update dynamic follow
     else:
       TR = 1.8

--- a/selfdrive/controls/tests/test_following_distance.py
+++ b/selfdrive/controls/tests/test_following_distance.py
@@ -29,7 +29,7 @@ def run_following_distance_simulation(v_lead, t_end=200.0):
   v_ego = v_lead
   a_ego = 0.0
 
-  mpc = LeadMpc(0)
+  mpc = LeadMpc(0, test=True)
 
   first = True
   while t < t_end:


### PR DESCRIPTION
To ensure nothing about the MPC has changed since we've added adjustable following distance