### PR TITLE
Add Ability to Hide Model Long Button

### DIFF
--- a/common/op_params.py
+++ b/common/op_params.py
@@ -125,7 +125,7 @@ class opParams:
                         'support_white_panda': Param(False, bool, 'Enable this to allow engagement with the deprecated white panda.\n'
                                                                   'localizer might not work correctly', static=True),
                         'disable_charging': Param(30, NUMBER, 'How many hours until charging is disabled while idle', static=True),
-
+                        'hide_model_long': Param(False, bool, 'Enable this to hide the Model Long button on the screen', static=True),
                         'prius_use_pid': Param(False, bool, 'This enables the PID lateral controller with new a experimental derivative tune\n'
                                                             'False: stock INDI, True: TSS2-tuned PID', static=True),
                         'use_lqr': Param(False, bool, 'Enable this to use LQR as your lateral controller over default with any car', static=True),

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -138,6 +138,11 @@ ButtonsWindow::ButtonsWindow(QWidget *parent) : QWidget(parent) {
   btns_layout->addWidget(mlButton, 0, Qt::AlignHCenter | Qt::AlignBottom);
   btns_layout->addStretch(3);
 
+  std::string hide_model_long = util::read_file("/data/community/params/hide_model_long");
+  if (hide_model_long == "true"){
+    mlButton->hide();
+  }
+
   dfButton = new QPushButton("DF\nprofile");
   QObject::connect(dfButton, &QPushButton::clicked, [=]() {
     QUIState::ui_state.scene.dfButtonStatus = dfStatus < 3 ? dfStatus + 1 : 0;  // wrap back around


### PR DESCRIPTION
Add param `hide_model_long` which if set to true will hide the model long button from the UI.
