### PR TITLE
Add Param to Alter Dynamic Follow Alerts

### DIFF
--- a/common/op_params.py
+++ b/common/op_params.py
@@ -121,8 +121,8 @@ class opParams:
                         'df_button_alerts': Param('audible', str, 'Can be: (\'off\', \'silent\', \'audible\')\n'
                                                                   'How you want to be alerted when you change your dynamic following profile.\n'
                                                                   ' - \'audible\' generates a visible alert with an audible sound, ideal for the on screen\n'
-                                                                  'button that lacks any tactile feedback'
-                                                                  ' - \'silent\' generates a visible alert with no sound'
+                                                                  'button that lacks any tactile feedback\n'
+                                                                  ' - \'silent\' generates a visible alert with no sound\n'
                                                                   ' - \'off\' no alert or sound. Likely only of value on vehicles that provide feedback\n'
                                                                   'on the df profile through other means, such as with \'toyota_distance_btn\' enabled.'),
                         'log_auto_df': Param(False, bool, 'Logs dynamic follow data for auto-df', static=True),

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -118,6 +118,13 @@ class opParams:
                                                                'auto will reboot the device when an update is seen', static=True),
                         'dynamic_gas': Param(False, bool, 'Whether to use dynamic gas if your car is supported'),
                         'hide_auto_df_alerts': Param(False, bool, 'Hides the alert that shows what profile the model has chosen'),
+                        'df_button_alerts': Param('audible', str, 'Can be: (\'off\', \'silent\', \'audible\')\n'
+                                                                  'How you want to be alerted when you change your dynamic following profile.\n'
+                                                                  ' - \'audible\' generates a visible alert with an audible sound, ideal for the on screen\n'
+                                                                  'button that lacks any tactile feedback'
+                                                                  ' - \'silent\' generates a visible alert with no sound'
+                                                                  ' - \'off\' no alert or sound. Likely only of value on vehicles that provide feedback\n'
+                                                                  'on the df profile through other means, such as with \'toyota_distance_btn\' enabled.'),
                         'log_auto_df': Param(False, bool, 'Logs dynamic follow data for auto-df', static=True),
                         # 'dynamic_camera_offset': Param(False, bool, 'Whether to automatically keep away from oncoming traffic.\n'
                         #                                             'Works from 35 to ~60 mph (requires radar)'),

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -376,7 +376,11 @@ class Controls:
           df_alert += 'Silent'
           self.AM.SA_add(df_alert, extra_text_1=df_out.model_profile_text + ' (auto)')
           return
+      elif self.op_params.get('df_button_alerts') != 'off':
+        return
       else:
+        if self.op_params.get('df_button_alerts') != 'silent':
+          df_alert += 'Silent'
         self.AM.SA_add(df_alert, extra_text_1=df_out.user_profile_text, extra_text_2='Dynamic follow: {} profile active'.format(df_out.user_profile_text))
         return
 


### PR DESCRIPTION
Adds a `df_button_alerts` parameter allowing the options of:
audible - (default) Normal visual alert with audible beep.
silent - Normal visual alert with no audible beep.
off - No alert at all

I suspect that most users will want to stick with the audible alerts.  But at least for those using the toyota_distance_btn there is no longer a need for an audible beep as the tactile button provides sufficient feedback.

Additionally, there may not be a need for a visible alert either since the selected profile is displayed on the dash using the distance lines.