### PR TITLE
Longcontrol: remove starting state

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -14,7 +14,7 @@ ACCEL_MAX_ISO = 2.0  # m/s^2
 
 
 def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_future,
-                             output_accel, brake_pressed, cruise_standstill):
+                             brake_pressed, cruise_standstill):
   """Update longitudinal control state machine"""
   stopping_condition = (v_ego < 2.0 and cruise_standstill) or \
                        (v_ego < CP.vEgoStopping and
@@ -36,12 +36,6 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_fut
 
     elif long_control_state == LongCtrlState.stopping:
       if starting_condition:
-        long_control_state = LongCtrlState.starting
-
-    elif long_control_state == LongCtrlState.starting:
-      if stopping_condition:
-        long_control_state = LongCtrlState.stopping
-      elif output_accel >= CP.startAccel:
         long_control_state = LongCtrlState.pid
 
   return long_control_state
@@ -90,8 +84,8 @@ class LongControl():
     # Update state machine
     output_accel = self.last_output_accel
     self.long_control_state = long_control_state_trans(CP, active, self.long_control_state, CS.vEgo,
-                                                       v_target_future, output_accel,
-                                                       CS.brakePressed, CS.cruiseState.standstill)
+                                                       v_target_future, CS.brakePressed,
+                                                       CS.cruiseState.standstill)
 
     if self.long_control_state == LongCtrlState.off or CS.gasPressed:
       self.reset(CS.vEgo)
@@ -118,13 +112,6 @@ class LongControl():
       if not CS.standstill or output_accel > CP.stopAccel:
         output_accel -= CP.stoppingDecelRate * DT_CTRL
       output_accel = clip(output_accel, accel_limits[0], accel_limits[1])
-      self.reset(CS.vEgo)
-
-    # Intention is to move again, release brake fast before handing control to PID
-    elif self.long_control_state == LongCtrlState.starting:
-      if output_accel < CP.startAccel:
-        output_accel += CP.startingAccelRate * DT_CTRL
-      output_accel = min(output_accel, CP.startAccel)
       self.reset(CS.vEgo)
 
     self.last_output_accel = output_accel


### PR DESCRIPTION
No point in having a starting state which "releases brake." PID can do the same, and we don't have the effect of starting moving the `output_accel` to some arbitrary number only for PID control to jump the output to some other value. In Toyota stock ACC, the accel request jumps to whatever their controller wants near immediately.